### PR TITLE
[JENKINS-65161] Remove usage of Digester taken from Jenkins Core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-digester3</artifactId>
+            <version>3.2</version>
+        </dependency>
+        
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
             <version>1.38</version>

--- a/src/main/java/net/praqma/hudson/scm/ChangeLogParserImpl.java
+++ b/src/main/java/net/praqma/hudson/scm/ChangeLogParserImpl.java
@@ -49,7 +49,7 @@ public class ChangeLogParserImpl extends ChangeLogParser {
 	@Override
 	public ChangeLogSet<? extends Entry> parse( AbstractBuild build, File changelogFile ) throws IOException, SAXException {
 		List<ChangeLogEntryImpl> entries = new ArrayList<ChangeLogEntryImpl>();
-		Digester digester = createDigester(true);
+		Digester digester = createDigester(!Boolean.getBoolean(this.getClass().getName() + ".UNSAFE"));
 		digester.push( entries );
 		digester.addObjectCreate( "*/entry/activity", ChangeLogEntryImpl.class );
 		digester.addSetProperties( "*/entry/activity" );

--- a/src/main/java/net/praqma/hudson/scm/ChangeLogParserImpl.java
+++ b/src/main/java/net/praqma/hudson/scm/ChangeLogParserImpl.java
@@ -8,14 +8,15 @@ import java.util.List;
 import java.util.logging.Logger;
 
 import edu.umd.cs.findbugs.annotations.*;
-import org.apache.commons.digester.Digester;
+import org.apache.commons.digester3.Digester;
 import org.xml.sax.SAXException;
 
 import hudson.model.AbstractBuild;
 import hudson.scm.ChangeLogParser;
 import hudson.scm.ChangeLogSet;
 import hudson.scm.ChangeLogSet.Entry;
-import hudson.util.Digester2;
+
+import javax.xml.parsers.ParserConfigurationException;
 import java.util.logging.Level;
 
 /**
@@ -29,10 +30,26 @@ public class ChangeLogParserImpl extends ChangeLogParser {
 
 	protected static final Logger logger = Logger.getLogger( ChangeLogParserImpl.class.getName() );
 
+	private Digester createDigester(boolean secure) throws SAXException {
+		Digester digester = new Digester();
+		if (secure) {
+			digester.setXIncludeAware(false);
+			try {
+				digester.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+				digester.setFeature("http://xml.org/sax/features/external-general-entities", false);
+				digester.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+				digester.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+			} catch (ParserConfigurationException ex) {
+				throw new SAXException("Failed to securely configure xml digester parser", ex);
+			}
+		}
+		return digester;
+	}
+	
 	@Override
 	public ChangeLogSet<? extends Entry> parse( AbstractBuild build, File changelogFile ) throws IOException, SAXException {
 		List<ChangeLogEntryImpl> entries = new ArrayList<ChangeLogEntryImpl>();
-		Digester digester = new Digester2();
+		Digester digester = createDigester(true);
 		digester.push( entries );
 		digester.addObjectCreate( "*/entry/activity", ChangeLogEntryImpl.class );
 		digester.addSetProperties( "*/entry/activity" );


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This is a follow up PR for jenkinsci/jenkins#5320 tracked by https://issues.jenkins.io/browse/JENKINS-65161

We're removing Digester from Jenkins core because it's not used there. This PR adds Digester to this plugin and builds the object to parse xmls safely.

I can't validate the changes because a repository is no longer available. Any help about where to get those dependencies from would be appreciated:

```
<repository>
   <id>praqma-repo</id>
   <url></url>
</repository>
```

Desired reviewers per https://github.com/jenkins-infra/repository-permissions-updater/blob/master/permissions/plugin-clearcase-ucm-plugin.yml: 
@madsnielsen, @praqma

Additional reviewers:
@alecharp @rsandell @olamy @bitwiseman @car-roll 

- 
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
