### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/resources/net/praqma/hudson/scm/ChangeLogSetImpl/index.jelly
+++ b/src/main/resources/net/praqma/hudson/scm/ChangeLogSetImpl/index.jelly
@@ -34,7 +34,8 @@
                 <j:forEach var="file" items="${cs.affectedPaths}" varStatus="loop">
                     <tr>
                         <td width="16">
-                            <img width="16" height="16" src="/images/16x16/document_edit.png" alt="The file was modified" title="The file was modified"></img>
+                            <l:icon class="icon-notepad icon-sm"
+                                 alt="The file was modified" title="The file was modified"/>
                         </td>
                         <td>${cs.getOnlyChangedFile(file)} [${cs.getOnlyClearCaseChangedFile(file)}]</td>
                     </tr>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.
In case of your plugin, I've removed the header icons, because that is what modern Jenkins does now look like.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @atombrella 
Thanks in advance!